### PR TITLE
multi value initial replace

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,10 @@ module.exports = postcss.plugin('postcss-initial', function (opts) {
   var getFallback = makeFallbackFunction(opts.reset === 'inherited');
   return function (css) {
     css.walkDecls(function (decl) {
-      if (decl.value !== 'initial') return;
-      var fallBackRules = getFallback(decl.prop);
+      if (decl.value.indexOf('initial') < 0) {
+        return;
+      }
+      var fallBackRules = getFallback(decl.prop, decl.value);
       if (fallBackRules.length === 0) return;
       fallBackRules.forEach(function (rule) {
         decl.cloneBefore(rule);

--- a/lib/rules-fabric.js
+++ b/lib/rules-fabric.js
@@ -58,11 +58,11 @@ function _expandContainments(inputDecls) {
 
 var compiledDecls = _expandContainments(_compileDecls(decls));
 
-function _clearDecls(rules) {
+function _clearDecls(rules, value) {
   return rules.map(function (rule) {
     return {
       prop:  rule.prop,
-      value: rule.initial
+      value: value.replace(/initial/g, rule.initial)
     };
   });
 }
@@ -82,14 +82,14 @@ function _concreteDecl(declName) {
 }
 
 function makeFallbackFunction(onlyInherited) {
-  return function (declName) {
+  return function (declName, declValue) {
     var result;
     if (declName === 'all') {
       result = _allDecls(onlyInherited);
     } else {
       result = _concreteDecl(declName);
     }
-    return _clearDecls(result);
+    return _clearDecls(result, declValue);
   };
 }
 

--- a/test/fixtures/multivalue-replace.css
+++ b/test/fixtures/multivalue-replace.css
@@ -1,3 +1,7 @@
 div {
   background-repeat: initial initial;
 }
+
+div {
+  background-repeat: initial no-repeat;
+}

--- a/test/fixtures/multivalue-replace.css
+++ b/test/fixtures/multivalue-replace.css
@@ -1,0 +1,3 @@
+div {
+  background-repeat: initial initial;
+}

--- a/test/fixtures/multivalue-replace.expected.css
+++ b/test/fixtures/multivalue-replace.expected.css
@@ -1,3 +1,7 @@
 div {
   background-repeat: repeat repeat;
 }
+
+div {
+  background-repeat: repeat no-repeat;
+}

--- a/test/fixtures/multivalue-replace.expected.css
+++ b/test/fixtures/multivalue-replace.expected.css
@@ -1,0 +1,3 @@
+div {
+  background-repeat: repeat repeat;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -61,4 +61,11 @@ describe('postcss-initial', function () {
       { replace: true }
     );
   });
+  it('mutivalue - replaced', function () {
+    test(
+      f('multivalue-replace'),
+      f('multivalue-replace.expected'),
+      { replace: true }
+    );
+  });
 });


### PR DESCRIPTION
This PR addresses #16 

It might be that the declarations JSON should be augmented with some flag to permit multivalued replacements. For example, if a user accidentally writes `animation: initial initial;` this implementation will output `animation: none 0s ease 0s 1 normal none running none 0s ease 0s 1 normal none running;`. 

The flag `"mutilvalued": true` could act as a white list for properties that support many initial values. 

In any event it's a start :)
