### PR TITLE
Add `.eslintrc` to `.npmignore`.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+.eslintrc
 .gitignore
 
 node_modules/


### PR DESCRIPTION
Saves ~4KB from the package size.