### PR TITLE
Add CSS Standard Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PostCSS Initial
-[![Build Status][ci-img]][ci] [![NPM Module][npm-img]][npm] [![David DM][david-img]][david]
+[![CSS Standard Status][css-img]][css] [![Build Status][ci-img]][ci] [![NPM Module][npm-img]][npm] [![David DM][david-img]][david]
 
 <img align="right" width="135" height="95"
      title="Philosopher’s stone, logo of PostCSS"
@@ -9,6 +9,8 @@
 [postcss-autoreset][reset].
 
 [PostCSS]: https://github.com/postcss/postcss
+[css-img]: https://jonathantneal.github.io/css-db/badge/css-cascade-all-shorthand.svg
+[css]:     https://jonathantneal.github.io/css-db/#css-cascade-all-shorthand
 [ci-img]:  https://travis-ci.org/maximkoretskiy/postcss-initial.svg
 [ci]:      https://travis-ci.org/maximkoretskiy/postcss-initial
 [npm-img]: https://badge.fury.io/js/postcss-initial.svg
@@ -47,7 +49,7 @@ p {
 }
 ```
 
-**Killer feature!**  
+**Killer feature!**
 Universal reset from future css!
 ```css
 a {
@@ -147,16 +149,16 @@ a {
 
 ### reset
 
-Takes `string`.  
-Describes what subset of rules should be unsetted with `all` property (to reduce code weight).  
-Possible subsets: `all`, `inherited`.  
-Default value: `'all'`.  
+Takes `string`.
+Describes what subset of rules should be unsetted with `all` property (to reduce code weight).
+Possible subsets: `all`, `inherited`.
+Default value: `'all'`.
 
 ### replace
 
-Takes `boolean`.  
-Replace the `initial` with the fallback instead of adding it.  
-Default value: `false`.  
+Takes `boolean`.
+Replace the `initial` with the fallback instead of adding it.
+Default value: `false`.
 
 ## Usage
 


### PR DESCRIPTION
Hey there. I’m just trying to get the word out that cssdb has badges to help users know the status of your CSS polyfill.

[cssdb](https://jonathantneal.github.io/css-db/) is a list I’m compiling of CSS features and their positions in the process of becoming implemented web standards.