### PR TITLE
Only match full word `initial` occurrences

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = postcss.plugin('postcss-initial', function (opts) {
   };
   return function (css) {
     css.walkDecls(function (decl) {
-      if (decl.value.indexOf('initial') < 0) {
+      if (!/\binitial\b/.test(decl.value)) {
         return;
       }
       var fallBackRules = getFallback(decl.prop, decl.value);

--- a/lib/rules-fabric.js
+++ b/lib/rules-fabric.js
@@ -62,7 +62,7 @@ function _clearDecls(rules, value) {
   return rules.map(function (rule) {
     return {
       prop:  rule.prop,
-      value: value.replace(/initial/g, rule.initial)
+      value: value.replace(/\binitial\b/g, rule.initial)
     };
   });
 }

--- a/test/fixtures/negative.css
+++ b/test/fixtures/negative.css
@@ -1,0 +1,3 @@
+a {
+  animation: initiallyHidden 1s linear 0s 1;
+}

--- a/test/fixtures/negative.expected.css
+++ b/test/fixtures/negative.expected.css
@@ -1,0 +1,3 @@
+a {
+  animation: initiallyHidden 1s linear 0s 1;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -74,4 +74,10 @@ describe('postcss-initial', function () {
       { replace: true }
     );
   });
+  it('negative', function () {
+    test(
+      f('negative'),
+      f('negative.expected')
+    );
+  });
 });


### PR DESCRIPTION
I had an animation named `initiallyHide`, and noticed the compiled
output contained:
```css
animation: 0s ease 0s 1 none runninglyHide 1s linear 0s 1 normal none;
```
So the `initial` in `initiallyHide` was replaced with `running`.

This patch changes the replace regex to only match on word boundaries.

Thanks!